### PR TITLE
Fix styleUrls property

### DIFF
--- a/projects/smugglercode-ui/src/lib/Buttons/button/button.component.ts
+++ b/projects/smugglercode-ui/src/lib/Buttons/button/button.component.ts
@@ -5,7 +5,7 @@ import { ButtonType } from './enums/button-type.enum';
   selector: 'sc-button',
   imports: [],
   templateUrl: './button.component.html',
-  styleUrl: './button.component.scss',
+  styleUrls: ['./button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonComponent { 

--- a/projects/smugglercode-ui/src/lib/Buttons/icon-button/icon-button.component.ts
+++ b/projects/smugglercode-ui/src/lib/Buttons/icon-button/icon-button.component.ts
@@ -4,7 +4,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   selector: 'sc-icon-button',
   imports: [],
   templateUrl: './icon-button.component.html',
-  styleUrl: './icon-button.component.css',
+  styleUrls: ['./icon-button.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IconButtonComponent { }

--- a/projects/smugglercode-ui/src/lib/color-tools/color-list/color-list.component.ts
+++ b/projects/smugglercode-ui/src/lib/color-tools/color-list/color-list.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { ColorInfo } from '../models/color-info.model';
 import { NgFor, NgIf } from '@angular/common';
 import { HeaderComponent } from "../../typography/header/header.component";
@@ -7,7 +7,7 @@ import { HeaderComponent } from "../../typography/header/header.component";
   selector: 'sc-color-list',
   imports: [NgFor, NgIf, HeaderComponent],
   templateUrl: './color-list.component.html',
-  styleUrl: './color-list.component.scss',
+  styleUrls: ['./color-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ColorListComponent {

--- a/projects/smugglercode-ui/src/lib/color-tools/color-palette/color-palette.component.ts
+++ b/projects/smugglercode-ui/src/lib/color-tools/color-palette/color-palette.component.ts
@@ -6,7 +6,7 @@ import { ColorInfo } from '../models/color-info.model';
   selector: 'sc-color-palette',
   imports: [NgFor],
   templateUrl: './color-palette.component.html',
-  styleUrl: './color-palette.component.scss',
+  styleUrls: ['./color-palette.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ColorPaletteComponent { 

--- a/projects/smugglercode-ui/src/lib/color-tools/color-picker/color-picker.component.ts
+++ b/projects/smugglercode-ui/src/lib/color-tools/color-picker/color-picker.component.ts
@@ -7,7 +7,7 @@ import { TextBoxComponent } from "./../../inputs/text-box/text-box.component";
   selector: 'sc-color-picker',
   imports: [TextBoxComponent],
   templateUrl: './color-picker.component.html',
-  styleUrl: './color-picker.component.scss',
+  styleUrls: ['./color-picker.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ColorPickerComponent {

--- a/projects/smugglercode-ui/src/lib/forms/InputGroup/InputGroup.component.ts
+++ b/projects/smugglercode-ui/src/lib/forms/InputGroup/InputGroup.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
   selector: 'sc-input-group',
   imports: [NgIf],
   templateUrl: './InputGroup.component.html',
-  styleUrl: './InputGroup.component.scss',
+  styleUrls: ['./InputGroup.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InputGroupComponent { 

--- a/projects/smugglercode-ui/src/lib/inputs/check-box/check-box.component.ts
+++ b/projects/smugglercode-ui/src/lib/inputs/check-box/check-box.component.ts
@@ -5,7 +5,7 @@ import { NgIf} from '@angular/common'
   selector: 'sc-check-box',
   imports: [NgIf],
   templateUrl: './check-box.component.html',
-  styleUrl: './check-box.component.scss',
+  styleUrls: ['./check-box.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CheckBoxComponent {

--- a/projects/smugglercode-ui/src/lib/inputs/drop-down/drop-down.component.ts
+++ b/projects/smugglercode-ui/src/lib/inputs/drop-down/drop-down.component.ts
@@ -7,7 +7,7 @@ import { TextBoxComponent, FlyOutComponent, PropertyLogicService } from '../../.
   selector: 'sc-drop-down',
   imports: [FlyOutComponent, TextBoxComponent, NgTemplateOutlet, NgIf, NgFor],
   templateUrl: './drop-down.component.html',
-  styleUrl: './drop-down.component.scss',
+  styleUrls: ['./drop-down.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DropDownComponent<T> {

--- a/projects/smugglercode-ui/src/lib/inputs/text-box/text-box.component.ts
+++ b/projects/smugglercode-ui/src/lib/inputs/text-box/text-box.component.ts
@@ -5,7 +5,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Ou
   selector: 'sc-text-box',
   imports: [CommonModule],
   templateUrl: './text-box.component.html',
-  styleUrl: './text-box.component.scss',
+  styleUrls: ['./text-box.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextBoxComponent {

--- a/projects/smugglercode-ui/src/lib/overlay/fly-out/fly-out.component.ts
+++ b/projects/smugglercode-ui/src/lib/overlay/fly-out/fly-out.component.ts
@@ -5,7 +5,7 @@ import { NgIf } from '@angular/common'
   selector: 'sc-fly-out',
   imports: [NgIf],
   templateUrl: './fly-out.component.html',
-  styleUrl: './fly-out.component.scss',
+  styleUrls: ['./fly-out.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FlyOutComponent { 

--- a/projects/smugglercode-ui/src/lib/typography/header/header.component.ts
+++ b/projects/smugglercode-ui/src/lib/typography/header/header.component.ts
@@ -1,11 +1,11 @@
 import { NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
   selector: 'sc-header',
   imports: [NgIf],
   templateUrl: './header.component.html',
-  styleUrl: './header.component.scss',
+  styleUrls: ['./header.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HeaderComponent { 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,7 +5,7 @@ import { ColorInfo } from '../../projects/smugglercode-ui/src/lib/color-tools/mo
   selector: 'app-root',
   templateUrl: './app.component.html',
   standalone: false,
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'smugglercode-ui-sandbox';


### PR DESCRIPTION
## Summary
- use `styleUrls` in components instead of `styleUrl`
- remove stray `input` import from components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2968f7d0832dbd03fd1b6594b33c